### PR TITLE
feat: refactor the cc compute logic

### DIFF
--- a/cc/cc.go
+++ b/cc/cc.go
@@ -14,10 +14,13 @@ import (
 	"github.com/node-real/go-pkg/log"
 	"github.com/shopspring/decimal"
 
+	"github.com/bnb-chain/bsc-staking-indexer/model"
 	"github.com/bnb-chain/bsc-staking-indexer/store"
 )
 
 const url = "https://ccalert.bk.nodereal.cc/sendalerts"
+
+var weiPerEth = decimal.NewFromInt(1e18)
 
 // OperatorRewardConfig holds configuration for a single operator whose rewards are to be calculated.
 type OperatorRewardConfig struct {
@@ -56,6 +59,8 @@ func New(cfg Config, store store.Store) *CC {
 
 func (c *CC) Start() {
 	c.scheduler.StartAsync()
+	// for test
+	c.ComputeAndSend()
 }
 
 func (c *CC) ComputeAndSend() {
@@ -73,6 +78,8 @@ func (c *CC) ComputeAndSend() {
 		from = time.Date(year, month-1, 1, 0, 0, 0, 0, time.UTC)
 	}
 	to = time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	fromUnix := from.Unix()
+	toUnix := to.Unix()
 
 	log.Infow("[cc] Starting reward computation for period", "from", from, "to", to, "operators_count", len(c.cfg.Operators))
 
@@ -81,7 +88,7 @@ func (c *CC) ComputeAndSend() {
 
 		// 1. Calculate commission reward for the current operator
 		opCommissionWei := decimal.Zero
-		commissions, err := c.store.QueryBreathBlockRewardEvent(ctx, opCfg.OperatorAddress.Hex(), from.Unix(), to.Unix())
+		commissions, err := c.store.QueryBreathBlockRewardEvent(ctx, opCfg.OperatorAddress.Hex(), fromUnix, toUnix)
 		if err != nil {
 			log.Errorw("[cc] Failed to query commission events", "operator_name", opCfg.OperatorName, "operator_address", opCfg.OperatorAddress.Hex(), "err", err)
 			continue // Skip to the next operator
@@ -90,47 +97,62 @@ func (c *CC) ComputeAndSend() {
 			opCommissionWei = opCommissionWei.Add(commission.Commission)
 		}
 		// This is the commission amount to be reported and used in subtraction
-		opCommissionEthForReport := opCommissionWei.Div(decimal.NewFromInt(1e18))
+		opCommissionEthForReport := opCommissionWei.Div(weiPerEth)
 
 		// 2. Calculate total stake increase (operator's own + specific self-delegator's)
 		totalStakeIncreaseWei := decimal.Zero
+		totalNetDelegationWei := decimal.Zero
 
 		// 2a. Operator's own self-delegation reward
 		lastMonthOperatorStake, err := c.store.QueryDelegator(ctx, opCfg.OperatorAddress.Hex(),
-			opCfg.OperatorAddress.Hex(), from.Unix())
+			opCfg.OperatorAddress.Hex(), fromUnix)
 		if err != nil {
 			log.Errorw("[cc] Failed to query operator's own last month stake", "operator_name", opCfg.OperatorName, "delegator_address", opCfg.OperatorAddress.Hex(), "validator_address", opCfg.OperatorAddress.Hex(), "err", err)
 			continue // Skip to the next operator
 		}
 		thisMonthOperatorStake, err := c.store.QueryDelegator(ctx, opCfg.OperatorAddress.Hex(),
-			opCfg.OperatorAddress.Hex(), to.Unix())
+			opCfg.OperatorAddress.Hex(), toUnix)
 		if err != nil {
 			log.Errorw("[cc] Failed to query operator's own this month stake", "operator_name", opCfg.OperatorName, "delegator_address", opCfg.OperatorAddress.Hex(), "validator_address", opCfg.OperatorAddress.Hex(), "err", err)
 			continue // Skip to the next operator
 		}
 		operatorOwnStakeIncrease := thisMonthOperatorStake.Amount.Sub(lastMonthOperatorStake.Amount)
 		totalStakeIncreaseWei = totalStakeIncreaseWei.Add(operatorOwnStakeIncrease)
+		operatorNetDelegationWei, err := c.netDelegationChange(ctx, opCfg.OperatorAddress, opCfg.OperatorAddress, fromUnix, toUnix)
+		if err != nil {
+			log.Errorw("[cc] Failed to compute operator net delegation change", "operator_name", opCfg.OperatorName, "delegator_address", opCfg.OperatorAddress.Hex(), "err", err)
+			continue
+		}
+		totalNetDelegationWei = totalNetDelegationWei.Add(operatorNetDelegationWei)
 
 		// 2b. Reward from the specific "self-delegation" address, if configured
 		if opCfg.SelfDelegationAddress != (common.Address{}) { // Check if a specific self-delegation address is provided
 			lastMonthSpecialDelegatorStake, err := c.store.QueryDelegator(ctx, opCfg.SelfDelegationAddress.Hex(),
-				opCfg.OperatorAddress.Hex(), from.Unix())
+				opCfg.OperatorAddress.Hex(), fromUnix)
 			if err != nil {
 				// Log error but continue, as this part might be optional or fail independently
 				log.Errorw("[cc] Failed to query special delegator's last month stake", "operator_name", opCfg.OperatorName, "delegator_address", opCfg.SelfDelegationAddress.Hex(), "validator_address", opCfg.OperatorAddress.Hex(), "err", err)
 			} else {
 				thisMonthSpecialDelegatorStake, err := c.store.QueryDelegator(ctx, opCfg.SelfDelegationAddress.Hex(),
-					opCfg.OperatorAddress.Hex(), to.Unix())
+					opCfg.OperatorAddress.Hex(), toUnix)
 				if err != nil {
 					log.Errorw("[cc] Failed to query special delegator's this month stake", "operator_name", opCfg.OperatorName, "delegator_address", opCfg.SelfDelegationAddress.Hex(), "validator_address", opCfg.OperatorAddress.Hex(), "err", err)
 				} else {
-					specialDelegatorStakeIncrease := thisMonthSpecialDelegatorStake.Amount.Sub(lastMonthSpecialDelegatorStake.Amount)
-					totalStakeIncreaseWei = totalStakeIncreaseWei.Add(specialDelegatorStakeIncrease)
+					specialNetDelegationWei, err := c.netDelegationChange(ctx, opCfg.SelfDelegationAddress, opCfg.OperatorAddress, fromUnix, toUnix)
+					if err != nil {
+						log.Errorw("[cc] Failed to compute special delegator net delegation change", "operator_name", opCfg.OperatorName, "delegator_address", opCfg.SelfDelegationAddress.Hex(), "err", err)
+						// Skip adding special delegator's stake increase if we can't get net delegation
+					} else {
+						specialDelegatorStakeIncrease := thisMonthSpecialDelegatorStake.Amount.Sub(lastMonthSpecialDelegatorStake.Amount)
+						totalStakeIncreaseWei = totalStakeIncreaseWei.Add(specialDelegatorStakeIncrease)
+						totalNetDelegationWei = totalNetDelegationWei.Add(specialNetDelegationWei)
+					}
 				}
 			}
 		}
 
-		totalStakeIncreaseEth := totalStakeIncreaseWei.Div(decimal.NewFromInt(1e18))
+		totalStakeIncreaseNetWei := totalStakeIncreaseWei.Sub(totalNetDelegationWei)
+		totalStakeIncreaseEth := totalStakeIncreaseNetWei.Div(weiPerEth)
 
 		// This calculation mirrors the original logic for "Self-delegation reward"
 		finalSelfDelegationRewardForReport := totalStakeIncreaseEth.Sub(opCommissionEthForReport)
@@ -157,6 +179,42 @@ type Config struct {
 type Payload struct {
 	GroupID string `json:"groupID"`
 	MSG     string `json:"msg"`
+}
+
+func (c *CC) netDelegationChange(ctx context.Context, delegator common.Address, operator common.Address, fromTimestamp, toTimestamp int64) (decimal.Decimal, error) {
+	if delegator == (common.Address{}) {
+		return decimal.Zero, nil
+	}
+
+	txs, err := c.store.QueryDelegateTxs(ctx, delegator.Hex(), fromTimestamp, toTimestamp)
+	if err != nil {
+		return decimal.Zero, err
+	}
+
+	net := decimal.Zero
+	operatorHex := operator.Hex()
+
+	for _, tx := range txs {
+		switch tx.Action {
+		case model.Delegate:
+			if tx.SrcOperator == operatorHex {
+				net = net.Add(tx.Amount)
+			}
+		case model.UnDelegate:
+			if tx.SrcOperator == operatorHex {
+				net = net.Sub(tx.Amount)
+			}
+		case model.ReDelegate:
+			if tx.SrcOperator == operatorHex {
+				net = net.Sub(tx.Amount)
+			}
+			if tx.DstOperator == operatorHex {
+				net = net.Add(tx.Amount)
+			}
+		}
+	}
+
+	return net, nil
 }
 
 func SendCCMessage(groupID string, msg string) {

--- a/store/store.go
+++ b/store/store.go
@@ -25,6 +25,7 @@ type Store interface {
 
 	QueryBreathBlockRewardEvent(ctx context.Context, operator string, fromDate, toDate int64) ([]*model.BreathBlockRewardEvent, error)
 	QueryDelegator(ctx context.Context, delegator, operator string, startDateOfNextMonth int64) (*model.Delegator, error)
+	QueryDelegateTxs(ctx context.Context, delegator string, fromTimestamp, toTimestamp int64) ([]*model.DelegateTx, error)
 }
 
 type store struct {
@@ -146,4 +147,13 @@ func (s *store) QueryDelegator(ctx context.Context, delegator, operator string, 
 		"delegator = ? AND operator = ? AND date < ?",
 		delegator, operator, startDateOfNextMonth).Order("date desc").Limit(1).Find(&res).Error
 	return res, err
+}
+
+func (s *store) QueryDelegateTxs(ctx context.Context, delegator string, fromTimestamp, toTimestamp int64) (
+	[]*model.DelegateTx, error) {
+	var txs []*model.DelegateTx
+	err := s.db.WithContext(ctx).Model(&model.DelegateTx{}).Where(
+		"delegator = ? AND timestamp >= ? AND timestamp < ?",
+		delegator, fromTimestamp, toTimestamp).Order("timestamp asc").Find(&txs).Error
+	return txs, err
 }


### PR DESCRIPTION
fix: correct self-delegation reward calculation by excluding mid-month deposits/withdrawals

Previously, the reward calculation used raw stake delta (end - start), which incorrectly counted any delegate/undelegate operations during the month as rewards.

Now queries delegate_tx table to compute net delegation changes and subtracts them from stake delta, ensuring only actual staking rewards are reported.

Changes:
- Add QueryDelegateTxs to store for querying delegation transactions by time range
- Add netDelegationChange helper to compute net flow (delegate - undelegate ± redelegate)
- Update ComputeAndSend to subtract net delegation from stake increase before calculating rewards